### PR TITLE
[Feature/#14] role 전역 상태 관리 방법 변경

### DIFF
--- a/src/api/postLogIn.ts
+++ b/src/api/postLogIn.ts
@@ -1,5 +1,5 @@
 import { Axios } from './Axios.ts';
-import { EncryptKeyInfo, LogInFormDataValues, Terms } from '../types';
+import { Auth, EncryptKeyInfo, LogInFormDataValues, Terms } from '../types';
 
 export const requestKey = async () => {
   const response = await Axios.get<EncryptKeyInfo>('/auth/key');
@@ -13,12 +13,12 @@ export const getTerms = async () => {
 
 export const postLogIn = async (
   logInFormData: LogInFormDataValues,
-  auth: 'user' | 'admin',
+  auth: Auth,
   rsaKeyStrategy: string
 ) => {
   const response = await Axios.post(
-    `/auth/${auth}/login?rsaKeyStrategy=${rsaKeyStrategy}`,
+    `/auth/${auth.toLowerCase()}/login?rsaKeyStrategy=${rsaKeyStrategy}`,
     logInFormData
   );
-  return response.data.accessToken;
+  return response.data;
 };

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -18,7 +18,7 @@ export const useAuthStore = create<AuthState>()(
       setRole: (role) => set({ role }),
     }),
     {
-      name: 'accessToken',
+      name: 'auth',
     }
   )
 );

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -28,7 +28,9 @@ export interface Terms {
   content: string;
 }
 
-export type Role = '' | 'USER' | 'STUDENT_COUNCIL' | 'BOOTH_MANAGER';
+export type Auth = 'USER' | 'ADMIN';
+
+export type Role = '' | 'STUDENT' | 'STUDENT_COUNCIL' | 'BOOTH_MANAGER';
 
 export interface DecodeJWT {
   role: Role;

--- a/src/utils/encryptionUtils.ts
+++ b/src/utils/encryptionUtils.ts
@@ -1,5 +1,6 @@
 import { JSEncrypt } from 'jsencrypt';
 import {
+  Auth,
   AuthFormValues,
   EncryptKeyInfo,
   LogInFormDataValues,
@@ -19,7 +20,7 @@ const encryptFunc = (value: string, key: string) => {
 const setEncryptData = (
   formData: AuthFormValues,
   encryptInfo: EncryptKeyInfo,
-  auth: 'user' | 'admin',
+  auth: Auth,
   terms?: TermsMap
 ): LogInFormDataValues => {
   const { rsaPublicKey, credentialKey } = encryptInfo;
@@ -29,11 +30,11 @@ const setEncryptData = (
     key: '',
   };
 
-  if (auth === 'user') {
+  if (auth === 'USER') {
     loginFormData.encryptedStudentId =
       encryptFunc(formData.id, rsaPublicKey) || '';
     loginFormData.terms = terms;
-  } else if (auth === 'admin') {
+  } else if (auth === 'ADMIN') {
     loginFormData.encryptedLoginId =
       encryptFunc(formData.id, rsaPublicKey) || '';
   }

--- a/src/utils/getAuth.ts
+++ b/src/utils/getAuth.ts
@@ -1,13 +1,14 @@
 import { useLocation } from 'react-router-dom';
+import { Auth } from '../types';
 
-const GetAuth = () => {
+const GetAuth = (): Auth => {
   const location = useLocation();
 
   if (location.pathname === '/login') {
-    return 'user';
+    return 'USER';
   }
   if (location.pathname === '/admin/login') {
-    return 'admin';
+    return 'ADMIN';
   }
   throw new Error('로그인 외 경로');
 };


### PR DESCRIPTION
- (기존) 프론트에서 JWT Token 디코딩 후 Payload에서 role 추출
(변경) 로그인 응답 response로 token과 role을 같이 받아서 전역상태로 관리

Closes #14 